### PR TITLE
chore: add repo metadata and expand npm keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,20 @@
   "version": "0.1.16",
   "description": "NodeRED nodes for baserow",
   "keywords": [
-    "node-red"
+    "node-red",
+    "baserow",
+    "database",
+    "low-code",
+    "no-code"
   ],
+  "homepage": "https://github.com/cedricziel/node-red-contrib-baserow#readme",
+  "bugs": {
+    "url": "https://github.com/cedricziel/node-red-contrib-baserow/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cedricziel/node-red-contrib-baserow.git"
+  },
   "files": [
     "examples",
     "baserow-credentials.js",
@@ -20,7 +32,7 @@
   "scripts": {
     "test": "mocha \"test/**/*_spec.js\""
   },
-  "author": "",
+  "author": "Cedric Ziel <cedric@cedric-ziel.com>",
   "license": "MIT",
   "node-red": {
     "version": ">=2.0.0",


### PR DESCRIPTION
## Summary
- Adds `repository`, `homepage`, `bugs` URLs so the npm page links back to GitHub
- Expands `keywords` to `node-red`, `baserow`, `database`, `low-code`, `no-code` for better discoverability
- Sets `author` field

## Notes
- Pure metadata change; no runtime impact.
- `chore:` type — release-please will roll this into the next release PR without bumping the version on its own.
- If you want the metadata published sooner, amend the commit body with `Release-As: 0.1.17` and force a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata including author information and expanded search keywords to improve package discoverability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cedricziel/node-red-contrib-baserow/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->