### PR TITLE
fix(ci): bump Node to 22 for the publish step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 22
           registry-url: https://registry.npmjs.org/
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci


### PR DESCRIPTION
## Why

The release-please workflow's publish step was pinned to Node 16. That's below the engine requirements of `libnpmpublish` (`^18.17.0 || >=20.5.0`), which is why every release since 0.1.2 has failed at `npm publish` with a misleading `E404` (auth-failure shaped). Combined with the `npm_token` secret rotation that just happened, this should unblock publishing.

## Effect

- Next release-please-generated release PR will, when merged, actually publish to npm under `@cedricziel/*`.
- Drops the `EBADENGINE` warnings.
- `fix(ci):` type ensures release-please will roll the **previously stuck** metadata (PR #96) plus this fix into a single release PR (0.1.17), instead of needing a separate force-release.

## Verification plan

1. Merge this PR.
2. release-please opens `chore(main): release 0.1.17`.
3. Merge that.
4. Watch the workflow run; expect a green `npm publish` step.
5. `https://www.npmjs.com/package/@cedricziel/node-red-contrib-baserow` shows 0.1.17 with the new metadata.