### PR TITLE
fix(ci): publish npm package with provenance attestation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 name: release-please
 
@@ -29,7 +30,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish --access public
+      - run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Why

- Triggers a release-please cycle for **0.1.18** so the now-fixed publish pipeline (Node 22 + working automation token) actually puts the package on npm.
- Adds real value while we're at it: `--provenance` makes npm record a signed, verifiable attestation linking the published tarball back to this commit and workflow run. The npm page will show a "Provenance" badge.

## Changes
- `permissions.id-token: write` so the runner can OIDC-mint the attestation.
- `npm publish --access public --provenance`

## Verify after merge
1. release-please opens `chore(main): release 0.1.18`.
2. Merge that.
3. Publish step runs with the new automation token; expect `Publishing to https://registry.npmjs.org/ … Successfully published`.
4. https://www.npmjs.com/package/@cedricziel/node-red-contrib-baserow shows `0.1.18` with metadata and a Provenance badge.